### PR TITLE
Fix initial load of relative module imports and link in CUCWD `frontend-app-learning` package.

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "redux": "4.2.0"
   },
   "devDependencies": {
-    "@edx/frontend-app-learning": "github:Pearson-Advance/frontend-app-learning",
+    "@edx/frontend-app-learning": "github:CUCWD/frontend-app-learning#a1416019c42eb964a768ebdf22a160fc4e357703",
     "@edx/frontend-build": "12.3.0",
     "@testing-library/jest-dom": "5.16.5",
     "@testing-library/react": "12.1.5",

--- a/src/features/outline/CourseOutline.jsx
+++ b/src/features/outline/CourseOutline.jsx
@@ -3,11 +3,11 @@ import { useSelector, useDispatch } from 'react-redux';
 import { useParams } from 'react-router';
 import { Button } from '@edx/paragon';
 
-import { fetchCourseOutline } from 'features/outline/data';
-import messages from 'features/outline/messages';
-import Section from 'features/outline/Section';
-import { FAILED, LOADING } from 'features/outline/data/slice';
-import { handleOutlineEvent } from 'features/outline/eventsHandler';
+import { fetchCourseOutline } from '../../features/outline/data';
+import messages from '../../features/outline/messages';
+import Section from '../../features/outline/Section';
+import { FAILED, LOADING } from '../../features/outline/data/slice';
+import { handleOutlineEvent } from '../../features/outline/eventsHandler';
 
 function CourseOutline() {
   const { courseId: courseIdFromUrl } = useParams();

--- a/src/features/outline/CourseOutline.test.jsx
+++ b/src/features/outline/CourseOutline.test.jsx
@@ -9,10 +9,10 @@ import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { Factory } from 'rosie';
 import { getConfig, initializeMockApp } from '@edx/frontend-platform';
 
-import CourseOutline from 'features/outline/CourseOutline';
-import { fetchCourseOutline } from 'features/outline/data';
+import CourseOutline from '../../features/outline/CourseOutline';
+import { fetchCourseOutline } from '../../features/outline/data';
 import { executeThunk } from 'testUtils';
-import messages from 'features/outline/messages';
+import messages from '../../features/outline/messages';
 
 initializeMockApp();
 jest.mock('react-router');

--- a/src/features/outline/Section.jsx
+++ b/src/features/outline/Section.jsx
@@ -5,10 +5,10 @@ import { Collapsible, IconButton } from '@edx/paragon';
 import { faCheckCircle as fasCheckCircle, faMinus, faPlus } from '@fortawesome/free-solid-svg-icons';
 import { faCheckCircle as farCheckCircle } from '@fortawesome/free-regular-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { handleOutlineEvent } from 'features/outline/eventsHandler';
+import { handleOutlineEvent } from '../../features/outline/eventsHandler';
 
-import SequenceLink from 'features/outline/SequenceLink';
-import messages from 'features/outline/messages';
+import SequenceLink from '../../features/outline/SequenceLink';
+import messages from '../../features/outline/messages';
 
 function Section({
   courseId,

--- a/src/features/outline/Section.test.jsx
+++ b/src/features/outline/Section.test.jsx
@@ -8,8 +8,8 @@ import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { Factory } from 'rosie';
 import { getConfig, initializeMockApp } from '@edx/frontend-platform';
 
-import Section from 'features/outline/Section';
-import { fetchCourseOutline } from 'features/outline/data';
+import Section from '../../features/outline/Section';
+import { fetchCourseOutline } from '../../features/outline/data';
 import { executeThunk } from 'testUtils';
 
 initializeMockApp();

--- a/src/features/outline/SequenceLink.jsx
+++ b/src/features/outline/SequenceLink.jsx
@@ -4,8 +4,8 @@ import { faCheckCircle as fasCheckCircle } from '@fortawesome/free-solid-svg-ico
 import { faCheckCircle as farCheckCircle } from '@fortawesome/free-regular-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Button } from '@edx/paragon';
-import messages from 'features/outline/messages';
-import { postEventOutlineToParent } from 'features/outline/eventsHandler';
+import messages from '../../features/outline/messages';
+import { postEventOutlineToParent } from '../../features/outline/eventsHandler';
 
 function SequenceLink({
   id,

--- a/src/features/outline/SequenceLink.test.jsx
+++ b/src/features/outline/SequenceLink.test.jsx
@@ -4,7 +4,7 @@ import {
 import { Provider } from 'react-redux';
 import initializeStore from 'store';
 
-import SequenceLink from 'features/outline/SequenceLink';
+import SequenceLink from '../../features/outline/SequenceLink';
 
 describe('Section', () => {
   let store;

--- a/src/features/outline/data/api.js
+++ b/src/features/outline/data/api.js
@@ -3,7 +3,7 @@ import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { logInfo } from '@edx/frontend-platform/logging';
 
 // eslint-disable-next-line import/no-self-import, import/no-cycle
-import { normalizeOutlineBlocks as exportedNormalizeOutlineBlocks } from 'features/outline/data/api';
+import { normalizeOutlineBlocks as exportedNormalizeOutlineBlocks } from '../../../features/outline/data/api';
 
 /**
   * A function that normalizes all blocks received from the outline API.

--- a/src/features/outline/data/index.js
+++ b/src/features/outline/data/index.js
@@ -1,5 +1,5 @@
 export {
   fetchCourseOutline,
-} from 'features/outline/data/thunks';
+} from '../../../features/outline/data/thunks';
 
-export { reducer } from 'features/outline/data/slice';
+export { reducer } from '../../../features/outline/data/slice';

--- a/src/features/outline/data/thunks.js
+++ b/src/features/outline/data/thunks.js
@@ -1,11 +1,11 @@
 import { logError } from '@edx/frontend-platform/logging';
 
-import { getCourseOutlineData } from 'features/outline/data/api';
+import { getCourseOutlineData } from '../../../features/outline/data/api';
 import {
   fetchCourseOutlineFailure,
   fetchCourseOutlineRequest,
   fetchCourseOutlineSuccess,
-} from 'features/outline/data/slice';
+} from '../../../features/outline/data/slice';
 
 /**
   * A thunk to make all the fetching cycle of the outline.

--- a/src/features/outline/data/thunks.test.js
+++ b/src/features/outline/data/thunks.test.js
@@ -6,12 +6,12 @@ import { logError } from '@edx/frontend-platform/logging';
 
 import initializeStore from 'store';
 import { executeThunk } from 'testUtils';
-import { fetchCourseOutline } from 'features/outline/data';
+import { fetchCourseOutline } from '../../features/outline/data';
 import {
   fetchCourseOutlineFailure,
   fetchCourseOutlineRequest,
   fetchCourseOutlineSuccess,
-} from 'features/outline/data/slice';
+} from '../../features/outline/data/slice';
 
 initializeMockApp();
 jest.mock('@edx/frontend-platform/logging');

--- a/src/features/outline/eventsHandler.test.js
+++ b/src/features/outline/eventsHandler.test.js
@@ -1,4 +1,4 @@
-import { postEventOutlineToParent, handleOutlineEvent } from 'features/outline/eventsHandler';
+import { postEventOutlineToParent, handleOutlineEvent } from '../../features/outline/eventsHandler';
 import { getConfig } from '@edx/frontend-platform';
 
 describe('postEventOutlineToParent', () => {

--- a/src/features/outline/index.js
+++ b/src/features/outline/index.js
@@ -1,2 +1,2 @@
 /* eslint-disable no-restricted-exports */
-export { default } from 'features/outline/CourseOutline';
+export { default } from '../../features/outline/CourseOutline';

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { Switch } from 'react-router-dom';
 
-import CourseOutline from 'features/outline/CourseOutline';
+import CourseOutline from './features/outline/CourseOutline';
 
 import './index.scss';
 import initializeStore from './store';

--- a/src/store.js
+++ b/src/store.js
@@ -1,5 +1,5 @@
 import { configureStore } from '@reduxjs/toolkit';
-import { reducer as outlineReducer } from 'features/outline/data';
+import { reducer as outlineReducer } from './features/outline/data';
 
 export default function initializeStore() {
   return configureStore({


### PR DESCRIPTION
The React modules were not loading properly in a Ubuntu environment, so I fixed relative paths to make it load properly.

Also, linked in `CUCWD/frontend-app-learning` as package instead of Pearson-Advance.